### PR TITLE
Fix inconsistent JVM target

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,13 @@ android {
         versionName "1.0"
         archivesBaseName = "adaptive-icon-playground"
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
## Summary
- align Kotlin and Java targets to version 1.8 to avoid Gradle build error

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c1e8a08488321b7f14bbbbdce7c48